### PR TITLE
Fix not binding on SDK >= 30: Add queries specification to the manifest

### DIFF
--- a/OsmAnd-api-sample/app/src/main/AndroidManifest.xml
+++ b/OsmAnd-api-sample/app/src/main/AndroidManifest.xml
@@ -2,6 +2,11 @@
 <manifest package="net.osmand.osmandapidemo"
           xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <queries>
+        <package android:name="net.osmand" />
+        <package android:name="net.osmand.plus" />
+    </queries>
+          
     <application
         android:allowBackup="true"
         android:icon="@mipmap/api_app"


### PR DESCRIPTION
In order for the app to bind the service on SDK >= 30, \<queries\> with required packages must be specified in the manifest.

[queries  | Android Developers](https://developer.android.com/guide/topics/manifest/queries-element)