### PR TITLE
Add GitHub workflows

### DIFF
--- a/.github/workflows/build-api-apk.yml
+++ b/.github/workflows/build-api-apk.yml
@@ -21,7 +21,8 @@ jobs:
       uses: actions/setup-java@v3
       with:
         java-version: '11'
-        distribution: 'adopt'
+        distribution: 'temurin'
+        cache: gradle
 
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew

--- a/.github/workflows/build-api-apk.yml
+++ b/.github/workflows/build-api-apk.yml
@@ -33,5 +33,5 @@ jobs:
       uses: actions/upload-artifact@v3
       with: 
         name: debug-api-sample-apk
-        path: app/build/outputs/apk/debug/*.apk
+        path: OsmAnd-api-sample/app/build/outputs/apk/debug/*.apk
         retention-days: 90

--- a/.github/workflows/build-api-apk.yml
+++ b/.github/workflows/build-api-apk.yml
@@ -1,0 +1,37 @@
+name: Build OsmAnd-api-sample apk
+
+on:
+  [workflow_dispatch]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: ./OsmAnd-api-sample
+        
+    steps:
+    - uses: actions/checkout@v3
+    - name: set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'adopt'
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    - name: Build with Gradle
+      run: ./gradlew assembleDebug
+    - name: Rename APK
+      run: mv app/build/outputs/apk/debug/app-debug.apk app/build/outputs/apk/debug/OsmAnd-api-sample-debug-$(git log -n 1 --format='%h').apk
+    - name: Archive APK
+      uses: actions/upload-artifact@v3
+      with: 
+        name: debug-api-sample-apk
+        path: app/build/outputs/apk/debug/*.apk
+        retention-days: 90

--- a/.github/workflows/build-map-apk.yml
+++ b/.github/workflows/build-map-apk.yml
@@ -21,7 +21,8 @@ jobs:
       uses: actions/setup-java@v3
       with:
         java-version: '11'
-        distribution: 'adopt'
+        distribution: 'temurin'
+        cache: gradle
 
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew

--- a/.github/workflows/build-map-apk.yml
+++ b/.github/workflows/build-map-apk.yml
@@ -1,0 +1,37 @@
+name: Build OsmAnd-map-sample apk
+
+on:
+  [workflow_dispatch]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: ./OsmAnd-map-sample
+        
+    steps:
+    - uses: actions/checkout@v3
+    - name: set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'adopt'
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    - name: Build with Gradle
+      run: ./gradlew assembleDebug
+    - name: Rename APK
+      run: mv app/build/outputs/apk/debug/app-debug.apk app/build/outputs/apk/debug/OsmAnd-map-sample-debug-$(git log -n 1 --format='%h').apk
+    - name: Archive APK
+      uses: actions/upload-artifact@v3
+      with: 
+        name: debug-map-sample-apk
+        path: OsmAnd-map-sample/app/build/outputs/apk/debug/*.apk
+        retention-days: 90

--- a/.github/workflows/build-map-apk.yml
+++ b/.github/workflows/build-map-apk.yml
@@ -28,11 +28,9 @@ jobs:
       run: chmod +x gradlew
     - name: Build with Gradle
       run: ./gradlew assembleDebug
-    - name: Rename APK
-      run: mv app/build/outputs/apk/debug/app-debug.apk app/build/outputs/apk/debug/OsmAnd-map-sample-debug-$(git log -n 1 --format='%h').apk
     - name: Archive APK
       uses: actions/upload-artifact@v3
       with: 
         name: debug-map-sample-apk
-        path: OsmAnd-map-sample/app/build/outputs/apk/debug/*.apk
+        path: OsmAnd-map-sample/app/build/outputs/apk/*/debug/*.apk
         retention-days: 90

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# osmand-api-demo
+Examples of usage for OsmAnd API & SDK
+
+- see https://osmand.net/docs/technical/osmand-api-sdk/ for instructions and differences
+- you can use GitHub Actions to build projects in your fork (if you don't have Android build environment yourself)


### PR DESCRIPTION
- Add GitHub workflows for letting GitHub build sample apps on demand (so people can easily let GitHub build `.apk` sample apps even without having Android development environment setup)
- Add simple README to point to documentation

The workflows were tested and work fine (e.g. https://github.com/mnalis/osmand-api-demo/actions/runs/4770040939 and https://github.com/mnalis/osmand-api-demo/actions/runs/4770040376)